### PR TITLE
chore: Mark as threadsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <jacoco.unit-tests.limit.instruction-ratio>25%</jacoco.unit-tests.limit.instruction-ratio>
     <java.version>25</java.version>
     <junit.version>6.0.3</junit.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
     <maven-core.version>3.9.14</maven-core.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
@@ -45,9 +46,9 @@
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <palantir.version>2.39.0</palantir.version>
+    <palantir.version>2.96.0</palantir.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
+    <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -146,6 +147,10 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/com/github/ngeor/yak4j/FilenameConventionsMojo.java
+++ b/src/main/java/com/github/ngeor/yak4j/FilenameConventionsMojo.java
@@ -18,7 +18,7 @@ import org.codehaus.plexus.util.FileUtils;
 /**
  * A mojo that checks filename conventions.
  */
-@Mojo(name = "check", defaultPhase = LifecyclePhase.VALIDATE)
+@Mojo(name = "check", defaultPhase = LifecyclePhase.VALIDATE, threadSafe = true)
 public class FilenameConventionsMojo extends AbstractMojo {
     @Parameter(required = true)
     private File directory;


### PR DESCRIPTION
Marked as threadsafe:
- the plugin's single Mojo (FilenameConventionsMojo) has no mutable static state
- no shared non-threadsafe collections, and
- no non-threadsafe formatters